### PR TITLE
Added missing libncurses5 install to CI

### DIFF
--- a/.github/workflows/non-omv.yml
+++ b/.github/workflows/non-omv.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Test tellurium
       run: |
         pip install tellurium
+        sudo apt-get install libncurses5 --fix-missing
         cd tellurium
         python simple.py -nogui
 


### PR DESCRIPTION
Fixes failing tests for non OMV scripts.  For whatever reason libncurses5 is no longer installed with tellurium in its most recent release.