### PR TITLE
Add pre-commit configuration and pyproject.toml and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ arm64
 /SBML/ex9.csv
 /SBML/hr.csv
 /test_suite/semantic/
+/test_suite/SBML_test_suite/
 /test_suite/semantic_tests_with_sedml_and_graphs.v*.zip*
 .vscode
 /BioModels/cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,50 @@
+# Formatting shouldn't be applied to auto generated files,
+# or files taken verbatim from external resources.
+exclude: |-
+  (?x)^(
+      LEMS/.*|
+      Brian/.*|
+      NEURON/.*|
+      NeuroML2/.*|
+      tellurium/simple.py*|
+      .*\.xml$|
+      .*\.sedml$|
+      .*\.sbml$|
+      .*\.omex$|
+      .*\.json$|
+      .*\.md$|
+  )$
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.1
+    hooks:
+      - id: ruff
+      - id: ruff-format
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.24.2
+    hooks:
+      - id: toml-sort-fix
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        args:
+          - --quote-props=as-needed
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args:
+          - --fix=lf
+      - id: trailing-whitespace
+
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+      - id: isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "SBMLShowcase"
+dynamic = ["version"]
+requires-python = ">=3.9"
+dependencies = [
+  "pyNeuroML[annotations]",
+  "python-libsedml",
+  "tellurium",
+  "pymetadata>=0.4.2",
+  "docker",
+  "requests<2.32.0"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pre-commit"
+]
+
+[tool.setuptools]
+packages = []


### PR DESCRIPTION
## pyproject toml and pre-commit config

Adds:
- very lightweight `pyproject.toml` to make it easy for potential users to install the correct environment
- a `pre-commit-config.yaml`
- ran pre-commit hooks on all files and fixed linting and  formatting errors

pre-commit hooks exclude `tellurium/simple.py`, files with `.xml`, `.sedml`, `.sbml` and `.omex`, 'json', and 'md' extensions, and files in the following folders:
- LEMS
- Brian
- NEURON
- NeuroML2
